### PR TITLE
getting rid of the script tag for the markdown dropdown

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -117,7 +117,7 @@
 	</footer>
 
 	<script src="https://www.gstatic.com/firebasejs/4.10.1/firebase.js"></script>
-	<script src="{{ site.baseurl }}/js/markdown-collapse.js"></script>
+	<!-- <script src="{{ site.baseurl }}/js/markdown-collapse.js"></script> -->
 	<script>
 		// Initialize Firebase
 		var config = {


### PR DESCRIPTION
Look at the live site at the bottom of all the pages.  That weird thing was generated by this script tag here in the default.html.  Removing it didn't impact @bellindj 's blog post where I think he's doing this with html.